### PR TITLE
Full exe path

### DIFF
--- a/packer/files/filetransfer/check_incoming_status.sh
+++ b/packer/files/filetransfer/check_incoming_status.sh
@@ -4,6 +4,6 @@ if [[ -z $(find /home/filetransfer/incoming/*.csv -mtime 0) ]]; then
   echo -e "To: {{NO_FILE_EMAILS}}\nSubject: No file in 24 hours\n" > /tmp/warn_email.txt
   echo -e "The latest files (files deleted every 7 days):\n" >> /tmp/warn_email.txt
   ls -l /home/filetransfer/incoming/*.csv | awk '{print $9" UTC:"$6" "$7" "$8}' >> /tmp/warn_email.txt
-  cat /tmp/warn_email.txt | sendmail -F "Donate Server" -f noreply@peacecorps.gov -t
+  cat /tmp/warn_email.txt | /usr/sbin/sendmail -F "Donate Server" -f noreply@peacecorps.gov -t
   rm /tmp/warn_email.txt
 fi


### PR DESCRIPTION
This will get annoying pretty fast. I think we can set NO_FILE_EMAILS to an empty string on demo to keep it quiet.

Until a shared volume is created, it might be a good idea to manually copy the last upload file over when deploying. Or, just live with the extra emails.