### PR TITLE
Sort by name rather than modification time. Use full aws path in cron

### DIFF
--- a/packer/files/filetransfer/sync_accounting
+++ b/packer/files/filetransfer/sync_accounting
@@ -1,1 +1,1 @@
-17 * * * * root bash /home/peacecorps/manage.sh sync_accounting `ls -t1 /home/filetransfer/incoming/*.csv | head -n 1`
+17 * * * * root bash /home/peacecorps/manage.sh sync_accounting `ls -r /home/filetransfer/incoming/*.csv | head -n 1`

--- a/packer/files/web/init.sh
+++ b/packer/files/web/init.sh
@@ -103,7 +103,7 @@ if [ $role = "admin" ]; then
 
     aws s3 cp s3://${aws_static_bucket_name}/filetransfers /home/filetransfer/incoming --recursive
     
-    echo "30 * * * * root bash aws s3 sync /home/filetransfer/incoming s3://%AWS_STATIC_BUCKET_NAME%/filetransfers --recursive" | tee /etc/cron.d/s3filetransferupload
+    echo "30 * * * * root bash /usr/local/bin/aws s3 sync /home/filetransfer/incoming s3://%AWS_STATIC_BUCKET_NAME%/filetransfers --recursive" | tee /etc/cron.d/s3filetransferupload
 
     PUBLIC_HOSTNAME=$(ec2metadata | grep 'public-hostname:' | cut -d ' ' -f 2)
 


### PR DESCRIPTION
* sort fixes a problem where, after downloading the latest from s3, files have the wrong timestamp leading to out of order syncs
* full aws resolves part of the s3 syncing problem, but I don't think fixes it entirely